### PR TITLE
Fix interface resolveType handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@apollo/subgraph": "^2.9.3",
+        "@graphql-tools/utils": "^10.7.2",
         "apollo-server-express": "^3.13.0",
         "express": "^4.21.2",
         "graphql": "^16.10.0"
@@ -268,6 +269,18 @@
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
+    "node_modules/@graphql-tools/mock/node_modules/@graphql-tools/utils": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
+      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@graphql-tools/mock/node_modules/value-or-promise": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
@@ -302,12 +315,17 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "version": "10.7.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.7.2.tgz",
+      "integrity": "sha512-Wn85S+hfkzfVFpXVrQ0hjnePa3p28aB6IdAGCiD1SqBCSMDRzL+OFEtyAyb30nV9Mqflqs9lCqjqlR2puG857Q==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-inspect": "1.0.1",
+        "dset": "^3.1.4",
         "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -837,6 +855,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/cross-inspect": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.1.tgz",
+      "integrity": "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/cssfilter": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
@@ -865,6 +894,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dset": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "private": true,
   "dependencies": {
     "@apollo/subgraph": "^2.9.3",
+    "@graphql-tools/utils": "^10.7.2",
     "apollo-server-express": "^3.13.0",
     "express": "^4.21.2",
     "graphql": "^16.10.0"


### PR DESCRIPTION
Found a way to fix interfaces in the resulting subgraph that comes out of buildSubgraphSchema() by following the same method to add custom directives, which are added after the subgraph has been built.

Apollo docs on the topic at https://www.apollographql.com/docs/federation/v1/subgraphs#directives-in-apollo-server-3x
Sample repository at https://github.com/apollographql/docs-examples/blob/main/apollo-server/v4/custom-directives/upper-case-directive/src/index.ts.

Now it works! 🎉 

![image](https://github.com/user-attachments/assets/54fec48f-1ec9-4938-b191-de7fca130e6b)
